### PR TITLE
fix(package): inicializo variable attempts antes de ejecutar el metod…

### DIFF
--- a/dist/package/lib/execute.js
+++ b/dist/package/lib/execute.js
@@ -28,6 +28,7 @@ Execute = function(settings) {
   this.outputFile = 'output';
   this.pathDone = process.cwd() + '/' + this.doneFile;
   this.pathOutput = process.cwd() + '/' + this.outputFile;
+  this.attempts = 0;
   return this;
 };
 

--- a/source/coffee/package/lib/css-url-versioner.coffee
+++ b/source/coffee/package/lib/css-url-versioner.coffee
@@ -49,7 +49,7 @@ CssUrlVersioner::generateVersion = () ->
 
 CssUrlVersioner::getLastCommit = () ->
 	command = "git log -1 --format=%h"
-
+	
 	exec = new Execute()
 	@sha1 = exec.runCommand(command)
 	

--- a/source/coffee/package/lib/execute.coffee
+++ b/source/coffee/package/lib/execute.coffee
@@ -22,6 +22,7 @@ Execute = (settings) ->
 	@outputFile = 'output'
 	@pathDone   = process.cwd() + '/' + @doneFile
 	@pathOutput = process.cwd() + '/' + @outputFile
+	@attempts   = 0
 	@
 
 Execute::runCommand = (command) ->


### PR DESCRIPTION
El problema consistía que al ejecutar el versionado, en algunos casos no terminaba de compilar.

Investigando encontré que en la función `Execute.prototype.readFile` del archivo `execute.js`, se ejecuta un `while` donde aumentaba la variable `this.attempts++` y este mismo arrojó como valor `NaN`, debido a que no se inicializó antes.

Por ello inicializo la variable con cero para poder ejecutar correctamente la función.
`this.attempts = 0;` en la función `Execute.prototype.runCommand`
